### PR TITLE
チュートリアル8章　基本的なログイン機構

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem 'uglifier', '>= 1.3.0'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
+
+gem 'jquery-rails', '4.3.1'
+
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.3.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     listen (3.1.5)
@@ -284,6 +288,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   jbuilder (~> 2.5)
+  jquery-rails (= 4.3.1)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,8 @@
 // about supported directives.
 //
 //= require rails-ujs
+//= require jquery
+//= require bootstrap
 //= require activestorage
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/sessions.coffee
+++ b/app/assets/javascripts/sessions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-
-  def hello
-    render html: 'hello, world!'
-  end
+  include SessionsHelper
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
     else
       # エラーメッセージを作成する
-      flash[:danger] = 'Invalid email/password combination'
+      flash.now[:danger] = 'Invalid email/password combination'
       render 'new'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,6 +9,7 @@ class SessionsController < ApplicationController
       # ユーザーログイン後にユーザー情報のページにリダイレクトする
     else
       # エラーメッセージを作成する
+      flash[:danger] = 'Invalid email/password combination'
       render 'new'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,5 +15,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    log_out
+    redirect_to root_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test 'should get new' do
+    get login_path
+    assert_response :success
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,9 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-      # ユーザーログイン後にユーザー情報のページにリダイレクトする
+      log_in user
+      redirect_to user
     else
-      # エラーメッセージを作成する
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,18 @@
-require 'test_helper'
+class SessionsController < ApplicationController
 
-class SessionsControllerTest < ActionDispatch::IntegrationTest
-  test 'should get new' do
-    get login_path
-    assert_response :success
+  def new
+  end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user && user.authenticate(params[:session][:password])
+      # ユーザーログイン後にユーザー情報のページにリダイレクトする
+    else
+      # エラーメッセージを作成する
+      render 'new'
+    end
+  end
+
+  def destroy
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,11 +1,9 @@
 class SessionsController < ApplicationController
-
-  def new
-  end
+  def new; end
 
   def create
     user = User.find_by(email: params[:session][:email].downcase)
-    if user && user.authenticate(params[:session][:password])
+    if user&.authenticate(params[:session][:password])
       log_in user
       redirect_to user
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      log_in @user
       flash[:success] = 'Welcome to the Sample App!'
       redirect_to @user
     else

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -16,4 +16,10 @@ module SessionsHelper
   def logged_in?
     !current_user.nil?
   end
+
+  # 現在のユーザーをログアウトする
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,2 +1,8 @@
 module SessionsHelper
-end
+
+    # 渡されたユーザーでログインする
+    def log_in(user)
+      session[:user_id] = user.id
+    end
+  end
+  

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,5 +1,4 @@
 module SessionsHelper
-
   # 渡されたユーザーでログインする
   def log_in(user)
     session[:user_id] = user.id
@@ -7,9 +6,9 @@ module SessionsHelper
 
   # 現在ログイン中のユーザーを返す (いる場合)
   def current_user
-    if session[:user_id]
-      @current_user ||= User.find_by(id: session[:user_id])
-    end
+    return unless session[:user_id]
+
+    @current_user ||= User.find_by(id: session[:user_id])
   end
 
   # ユーザーがログインしていればtrue、その他ならfalseを返す

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,8 +1,19 @@
 module SessionsHelper
 
-    # 渡されたユーザーでログインする
-    def log_in(user)
-      session[:user_id] = user.id
+  # 渡されたユーザーでログインする
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  # 現在ログイン中のユーザーを返す (いる場合)
+  def current_user
+    if session[:user_id]
+      @current_user ||= User.find_by(id: session[:user_id])
     end
   end
-  
+
+  # ユーザーがログインしていればtrue、その他ならfalseを返す
+  def logged_in?
+    !current_user.nil?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,11 @@ class User < ApplicationRecord
 
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
+
+  # 渡された文字列のハッシュ値を返す
+  # def User.digest(string)
+  #   cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+  #                                                 BCrypt::Engine.cost
+  #   BCrypt::Password.create(string, cost: cost)
+  # end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,26 @@
     <%= link_to "sample app", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home",    root_path %></li>
-        <li><%= link_to "Help",    help_path %></li>
-        <li><%= link_to "Log in", '#' %></li>
+        <li><%= link_to "Home", root_path %></li>
+        <li><%= link_to "Help", help_path %></li>
+        <% if logged_in? %>
+          <li><%= link_to "Users", '#' %></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+              Account <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+              <li><%= link_to "Profile", current_user %></li>
+              <li><%= link_to "Settings", '#' %></li>
+              <li class="divider"></li>
+              <li>
+                <%= link_to "Log out", logout_path, method: :delete %>
+              </li>
+            </ul>
+          </li>
+        <% else %>
+          <li><%= link_to "Log in", login_path %></li>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,2 +1,19 @@
-<h1>Sessions#new</h1>
-<p>Find me in app/views/sessions/new.html.erb</p>
+<% provide(:title, "Log in") %>
+<h1>Log in</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(:session, url: login_path) do |f| %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.submit "Log in", class: "btn btn-primary" %>
+    <% end %>
+
+    <p>New user? <%= link_to "Sign up now!", signup_path %></p>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Sessions#new</h1>
+<p>Find me in app/views/sessions/new.html.erb</p>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      The form contains <%= pluralize(@user.errors.count, "error") %>.
+    </div>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'sessions/new'
   get 'users/new'
   root 'static_pages#home'
   get  '/help',    to: 'static_pages#help'
@@ -6,5 +7,8 @@ Rails.application.routes.draw do
   get  '/contact', to: 'static_pages#contact'
   get  '/signup',  to: 'users#new'
   post '/signup',  to: 'users#create'
+  get    '/login',   to: 'sessions#new'
+  post   '/login',   to: 'sessions#create'
+  delete '/logout',  to: 'sessions#destroy'
   resources :users
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+    factory :user do
+      name { 'Michael Example' }
+      email { 'michael@example.com' }
+      password { 'password' }
+      password_confirmation { 'password' }
+    end
+  end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
-    factory :user do
-      name { 'Michael Example' }
-      email { 'michael@example.com' }
-      password { 'password' }
-      password_confirmation { 'password' }
-    end
+  factory :user do
+    name { 'Michael Example' }
+    email { 'michael@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
   end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Sessions', type: :request do
+  describe 'GET /new' do
+    it 'returns http success' do
+      get '/sessions/new'
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,10 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe 'Sessions', type: :request do
-  describe 'GET /new' do
+  describe 'GET /login' do
     it 'returns http success' do
-      get '/sessions/new'
-      expect(response).to have_http_status(:success)
+      get login_path
+      expect(response).to have_http_status :success
+    end
+  end
+
+  describe 'DELETE /logout' do
+    it 'ログアウトできること' do
+      user = FactoryBot.create(:user)
+      post login_path, params: { session: { email: user.email,
+                                            password: user.password } }
+      expect(logged_in?).to be_truthy
+
+      delete logout_path
+      expect(logged_in?).to_not be_truthy
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe 'Users', type: :request do
         post users_path, params: user_params
         expect(flash).to be_any
       end
+
+      it 'ログイン状態であること' do
+        post users_path, params: user_params
+        expect(logged_in?).to be_truthy
+      end
     end
 
     context '無効な値の場合' do
@@ -48,6 +53,17 @@ RSpec.describe 'Users', type: :request do
                                              password_confimation: 'bar' } }
         end.to_not change(User, :count)
       end
+    end
+  end
+
+  describe 'DELETE /logout' do
+    it 'ログアウトできること' do
+      user = FactoryBot.create(:user)
+      post login_path, params: { session: { email: user.email,
+                                            password: user.password } }
+      expect(logged_in?).to be_truthy
+      delete logout_path
+      expect(logged_in?).to_not be_truthy
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -55,15 +55,4 @@ RSpec.describe 'Users', type: :request do
       end
     end
   end
-
-  describe 'DELETE /logout' do
-    it 'ログアウトできること' do
-      user = FactoryBot.create(:user)
-      post login_path, params: { session: { email: user.email,
-                                            password: user.password } }
-      expect(logged_in?).to be_truthy
-      delete logout_path
-      expect(logged_in?).to_not be_truthy
-    end
-  end
 end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,9 @@
+module LoginSupport
+    def logged_in?
+        !session[:user_id].nil?
+    end
+end
+
+RSpec.configure do |config|
+    config.include LoginSupport
+end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,9 +1,9 @@
 module LoginSupport
-    def logged_in?
-        !session[:user_id].nil?
-    end
+  def logged_in?
+    !session[:user_id].nil?
+  end
 end
 
 RSpec.configure do |config|
-    config.include LoginSupport
+  config.include LoginSupport
 end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+ 
+RSpec.describe "Sessions", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+ 
+  describe '#new' do
+    context '無効な値の場合' do
+      it 'flashメッセージが表示される' do
+        visit login_path
+ 
+        fill_in 'Email', with: ''
+        fill_in 'Password', with: ''
+        click_button 'Log in'
+
+        expect(page).to have_selector 'div.alert.alert-danger'
+
+        visit root_path
+        expect(page).to_not have_selector 'div.alert.alert-danger'
+      end
+    end
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe "Sessions", type: :system do
   end
  
   describe '#new' do
+    context '有効な値の場合' do
+      let(:user) { FactoryBot.create(:user) }  
+      it 'ログインユーザ用のページが表示されること' do
+        visit login_path  
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: user.password
+        click_button 'Log in'
+     
+       expect(page).to_not have_selector "a[href=\"#{login_path}\"]"
+        expect(page).to have_selector "a[href=\"#{logout_path}\"]"
+        expect(page).to have_selector "a[href=\"#{user_path(user)}\"]"
+      end
+    end
+
+
     context '無効な値の場合' do
       it 'flashメッセージが表示される' do
         visit login_path

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,30 +1,29 @@
 require 'rails_helper'
- 
-RSpec.describe "Sessions", type: :system do
+
+RSpec.describe 'Sessions', type: :system do
   before do
     driven_by(:rack_test)
   end
- 
+
   describe '#new' do
     context '有効な値の場合' do
-      let(:user) { FactoryBot.create(:user) }  
+      let(:user) { FactoryBot.create(:user) }
       it 'ログインユーザ用のページが表示されること' do
-        visit login_path  
+        visit login_path
         fill_in 'Email', with: user.email
         fill_in 'Password', with: user.password
         click_button 'Log in'
-     
-       expect(page).to_not have_selector "a[href=\"#{login_path}\"]"
+
+        expect(page).to_not have_selector "a[href=\"#{login_path}\"]"
         expect(page).to have_selector "a[href=\"#{logout_path}\"]"
         expect(page).to have_selector "a[href=\"#{user_path(user)}\"]"
       end
     end
 
-
     context '無効な値の場合' do
       it 'flashメッセージが表示される' do
         visit login_path
- 
+
         fill_in 'Email', with: ''
         fill_in 'Password', with: ''
         click_button 'Log in'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe 'Users', type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  describe '#create' do
+    context '無効な値の場合' do
+      it 'エラーメッセージ用の表示領域が描画されていること' do
+        visit signup_path
+        fill_in 'Name', with: ''
+        fill_in 'Email', with: 'user@invlid'
+        fill_in 'Password', with: 'foo'
+        fill_in 'Confirmation', with: 'bar'
+        click_button 'Create my account'
+
+        expect(page).to have_selector 'div#error_explanation'
+        expect(page).to have_selector 'div.field_with_errors'
+      end
+    end
+  end
+end


### PR DESCRIPTION
railsチュートリアル8章を参考に、基本的なログイン機構を実装しました。

・ログインフォームの作成（emailとpasswordの入力）
・ログインに失敗（無効な内容の入力）時、flashメッセージの表示
・セッションで現在ログインしているユーザーIDを保持　
　→ログイン状態に応じて画面のレイアウトやリンクが変化する
　　・画面右上
　　　未ログイン状態：log inページに遷移するボタン
　　　ログイン状態：「Account」と書かれたボタン　
　　　　　　　　　→押すとプルダウンでログインしているUserのProfile画面へ遷移するボタン
　　　　　　　　　　　　　　　　　　「Setting」ボタン（現状動作なし）
　　　　　　　　　　　　　　　　　　　log outを実行するボタン
・User登録時、自動でログイン


動作画面の録画：
https://github.com/Ryo-aio2/tutorial_3/assets/106331718/cc26bdec-6fef-46be-a46a-144dd834ce86

参考：
railsチュートリアル
https://railstutorial.jp/chapters/basic_login?version=5.1#cha-basic_login
RailsチュートリアルのテストをRSpecで書き換える
https://zenn.dev/fu_ga/books/ff025eaf9eb387