### PR TITLE
12章

### DIFF
--- a/app/assets/javascripts/password_resets.coffee
+++ b/app/assets/javascripts/password_resets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -26,6 +26,7 @@ class PasswordResetsController < ApplicationController
       render 'edit'
     elsif @user.update_attributes(user_params)
       log_in @user
+      @user.update_attribute(:reset_digest, nil)
       flash[:success] = 'Password has been reset.'
       redirect_to @user
     else

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,5 @@
+class PasswordResetsController < ApplicationController
+  def new; end
+
+  def edit; end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,5 +1,18 @@
 class PasswordResetsController < ApplicationController
   def new; end
 
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = 'Email sent with password reset instructions'
+      redirect_to root_url
+    else
+      flash.now[:danger] = 'Email address not found'
+      render 'new'
+    end
+  end
+
   def edit; end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,7 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user,   except: %i[new create]
+  before_action :valid_user, except: %i[new create]
+
   def new; end
 
   def create
@@ -15,4 +18,21 @@ class PasswordResetsController < ApplicationController
   end
 
   def edit; end
+
+  private
+
+  #getやset
+  # rubocop:disable Naming/AccessorMethodName
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+  # rubocop:enable Naming/AccessorMethodName
+
+  # 正しいユーザーかどうか確認する
+  def valid_user
+    unless @user&.activated? &&
+           @user&.authenticated?(:reset, params[:id])
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,6 +1,7 @@
 class PasswordResetsController < ApplicationController
   before_action :get_user,   except: %i[new create]
   before_action :valid_user, except: %i[new create]
+  before_action :check_expiration, except: %i[new create]
 
   def new; end
 
@@ -19,7 +20,24 @@ class PasswordResetsController < ApplicationController
 
   def edit; end
 
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, :blank)
+      render 'edit'
+    elsif @user.update_attributes(user_params)
+      log_in @user
+      flash[:success] = 'Password has been reset.'
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
   private
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
 
   # getやsetから始まるメソッド名は避けた方がよい→ここはチュートリアルに合わせてそのままにしておく
   # rubocop:disable Naming/AccessorMethodName
@@ -34,5 +52,13 @@ class PasswordResetsController < ApplicationController
            @user&.authenticated?(:reset, params[:id])
       redirect_to root_url
     end
+  end
+
+  # トークンが期限切れかどうか確認する
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = 'Password reset has expired.'
+    redirect_to new_password_reset_url
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,5 +1,5 @@
 class PasswordResetsController < ApplicationController
-  before_action :get_user,   except: %i[new create]
+  before_action :get_user,   only: %i[edit update]
   before_action :valid_user, except: %i[new create]
   before_action :check_expiration, except: %i[new create]
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -21,7 +21,7 @@ class PasswordResetsController < ApplicationController
 
   private
 
-  #getやset
+  # getやsetから始まるメソッド名は避けた方がよい→ここはチュートリアルに合わせてそのままにしておく
   # rubocop:disable Naming/AccessorMethodName
   def get_user
     @user = User.find_by(email: params[:email])

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,9 +4,9 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: 'Account activation'
   end
 
-  def password_reset
-    @greeting = 'Hi'
+  def password_reset(user)
+    @user = user
 
-    mail to: 'to@example.org'
+    mail to: user.email, subject: 'Password reset'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@
 #  index_users_on_email  (email) UNIQUE
 #
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   before_save   :downcase_email
   before_create :create_activation_digest
@@ -83,7 +83,19 @@ class User < ApplicationRecord
     UserMailer.account_activation(self).deliver_now
   end
 
+  # パスワード再設定の属性を追加する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_attribute(:reset_digest, User.digest(reset_token))
+    update_attribute(:reset_sent_at, Time.zone.now)
+  end
+
   private
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).de
+  end
 
   # メールアドレスをすべて小文字にする
   def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@
 #  name              :string           not null
 #  password_digest   :string           not null
 #  remember_digest   :string
+#  reset_digest      :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,8 +86,7 @@ class User < ApplicationRecord
   # パスワード再設定の属性を追加する
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attribute(:reset_digest,  User.digest(reset_token))
-    update_attribute(:reset_sent_at, Time.zone.now)
+    update(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
   end
 
   # パスワード再設定のメールを送信する

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@
 #  password_digest   :string           not null
 #  remember_digest   :string
 #  reset_digest      :string
+#  reset_sent_at     :datetime
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,6 +95,11 @@ class User < ApplicationRecord
     UserMailer.password_reset(self).deliver_now
   end
 
+  # パスワード再設定の期限が切れている場合はtrueを返す
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
+  end
+
   private
 
   # メールアドレスをすべて小文字にする

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,16 +86,16 @@ class User < ApplicationRecord
   # パスワード再設定の属性を追加する
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attribute(:reset_digest, User.digest(reset_token))
+    update_attribute(:reset_digest,  User.digest(reset_token))
     update_attribute(:reset_sent_at, Time.zone.now)
   end
 
-  private
-
   # パスワード再設定のメールを送信する
   def send_password_reset_email
-    UserMailer.password_reset(self).de
+    UserMailer.password_reset(self).deliver_now
   end
+
+  private
 
   # メールアドレスをすべて小文字にする
   def downcase_email

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,20 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<% provide(:title, 'Reset password') %>
+<h1>Reset password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Update password", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#new</h1>
+<p>Find me in app/views/password_resets/new.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,2 +1,13 @@
-<h1>PasswordResets#new</h1>
-<p>Find me in app/views/password_resets/new.html.erb</p>
+<% provide(:title, "Forgot password") %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(:password_reset, url: password_resets_path) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,6 +9,7 @@
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
+      <%= link_to "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,13 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
+                                                      email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,8 @@
-User#password_reset
+To reset your password click the link below:
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ module App
         helper_specs: false,
         routing_specs: false
     end
+
+    config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'password_resets/new'
+  get 'password_resets/edit'
   get 'sessions/new'
   get 'users/new'
   root 'static_pages#home'
@@ -12,4 +14,5 @@ Rails.application.routes.draw do
   delete '/logout',  to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets,     only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20230823073257_add_reset_to_users.rb
+++ b/db/migrate/20230823073257_add_reset_to_users.rb
@@ -1,0 +1,5 @@
+class AddResetToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :reset_digest, :string
+  end
+end

--- a/db/migrate/20230824052002_add_reset_to_users.rb
+++ b/db/migrate/20230824052002_add_reset_to_users.rb
@@ -1,5 +1,6 @@
 class AddResetToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_21_010747) do
+ActiveRecord::Schema.define(version: 2023_08_23_073257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2023_08_21_010747) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_23_073257) do
+ActiveRecord::Schema.define(version: 2023_08_24_052002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2023_08_23_073257) do
     t.boolean "activated", default: false
     t.datetime "activated_at"
     t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,7 @@
 #  name              :string           not null
 #  password_digest   :string           not null
 #  remember_digest   :string
+#  reset_digest      :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,7 @@
 #  password_digest   :string           not null
 #  remember_digest   :string
 #  reset_digest      :string
+#  reset_sent_at     :datetime
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -11,6 +11,8 @@ class UserMailerPreview < ActionMailer::Preview
   # Preview this email at
   # http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
+  let(:user) { FactoryBot.create(:user) }
+
   describe 'account_activation' do
-    let(:user) { FactoryBot.create(:user) }
     let(:mail) { UserMailer.account_activation(user) }
 
     before do
@@ -27,6 +28,33 @@ RSpec.describe UserMailer, type: :mailer do
 
     it 'メール本文にユーザのactivation_tokenが表示されていること' do
       expect(mail.body.encoded).to match(user.activation_token)
+    end
+
+    it 'メール本文にユーザのemailが表示されていること' do
+      expect(mail.body.encoded).to match(CGI.escape(user.email))
+    end
+  end
+
+  describe 'password_reset' do
+    let(:mail) { UserMailer.password_reset(user) }
+    before do
+      user.reset_token = User.new_token
+    end
+
+    it '"Password reset"というタイトルで送信されること' do
+      expect(mail.subject).to eq('Password reset')
+    end
+
+    it '送信先が"to@example.org"であること' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it '送信元が"from@example.com"であること' do
+      expect(mail.from).to eq(['noreply@example.com'])
+    end
+
+    it 'メール本文にreset_tokenが表示されていること' do
+      expect(mail.body.encoded).to match(user.reset_token)
     end
 
     it 'メール本文にユーザのemailが表示されていること' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@
 #  name              :string           not null
 #  password_digest   :string           not null
 #  remember_digest   :string
+#  reset_digest      :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,7 @@
 #  password_digest   :string           not null
 #  remember_digest   :string
 #  reset_digest      :string
+#  reset_sent_at     :datetime
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'PasswordResets', type: :request do
         patch password_reset_path(@user.reset_token), params: { email: @user.email,
                                                                 user: { password: 'foobaz',
                                                                         password_confirmation: 'foobaz' } }
-        expect(logged_in?).to be_truthy
+        expect(logged_in?).to be (true)
       end
 
       it 'flashが存在すること' do

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe 'PasswordResets', type: :request do
                                                                         password_confirmation: 'foobaz' } }
         expect(response).to redirect_to @user
       end
+
+      it 'reset_digestがnilになること' do
+        patch password_reset_path(@user.reset_token), params: { email: @user.email,
+                                                                user: { password: 'foobaz',
+                                                                        password_confirmation: 'foobaz' } }
+        @user.reload
+        expect(@user.reset_digest).to be_nil
+      end
     end
 
     it 'パスワードと再入力が一致しなければ、エラーメッセージが表示されること' do

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'PasswordResets', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe '#new' do
+    it 'password_reset[email]というname属性のinputタグが表示されること' do
+      get new_password_reset_path
+      expect(response.body).to include 'name="password_reset[email]"'
+    end
+  end
+
+  describe '#create' do
+    it '無効なメールアドレスならflashが存在すること' do
+      post password_resets_path, params: { password_reset: { email: '' } }
+      expect(flash).to_not be_empty
+    end
+
+    context '有効なメールアドレスの場合' do
+      it 'reset_digestが変わっていること' do
+        post password_resets_path, params: { password_reset: { email: user.email } }
+        expect(user.reset_digest).to_not eq user.reload.reset_digest
+      end
+
+      it '送信メールが1件増えること' do
+        expect do
+          post password_resets_path, params: { password_reset: { email: user.email } }
+        end.to change(ActionMailer::Base.deliveries, :count).by 1
+      end
+
+      it 'flashが存在すること' do
+        post password_resets_path, params: { password_reset: { email: user.email } }
+        expect(flash).to_not be_empty
+      end
+
+      it 'rootにリダイレクトされること' do
+        post password_resets_path, params: { password_reset: { email: user.email } }
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  describe '#edit' do
+    before do
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      @user = controller.instance_variable_get('@user')
+    end
+
+    it 'メールアドレスもトークンも有効なら、隠しフィールドにメールアドレスが表示されること' do
+      get edit_password_reset_path(@user.reset_token, email: @user.email)
+      expect(response.body).to include "<input type=\"hidden\" name=\"email\" id=\"email\" value=\"#{@user.email}\" />"
+    end
+
+    it 'メールアドレスが間違っていれば、rootにリダイレクトすること' do
+      get edit_password_reset_path(@user.reset_token, email: '')
+      expect(response).to redirect_to root_path
+    end
+
+    it '無効なユーザならrootにリダイレクトすること' do
+      @user.toggle!(:activated)
+      get edit_password_reset_path(@user.reset_token, email: @user.email)
+      expect(response).to redirect_to root_path
+    end
+
+    it 'トークンが無効なら、rootにリダイレクトすること' do
+      get edit_password_reset_path('wrong token', email: @user.email)
+      expect(response).to redirect_to root_path
+    end
+  end
+
+  describe '#update' do
+    before do
+      post password_resets_path, params: { password_reset: { email: user.email } }
+      @user = controller.instance_variable_get('@user')
+    end
+
+    context '有効なパスワードの場合' do
+      it 'ログイン状態になること' do
+        patch password_reset_path(@user.reset_token), params: { email: @user.email,
+                                                                user: { password: 'foobaz',
+                                                                        password_confirmation: 'foobaz' } }
+        expect(logged_in?).to be_truthy
+      end
+
+      it 'flashが存在すること' do
+        patch password_reset_path(@user.reset_token), params: { email: @user.email,
+                                                                user: { password: 'foobaz',
+                                                                        password_confirmation: 'foobaz' } }
+        expect(flash).to_not be_empty
+      end
+
+      it 'ユーザの詳細ページにリダイレクトすること' do
+        patch password_reset_path(@user.reset_token), params: { email: @user.email,
+                                                                user: { password: 'foobaz',
+                                                                        password_confirmation: 'foobaz' } }
+        expect(response).to redirect_to @user
+      end
+    end
+
+    it 'パスワードと再入力が一致しなければ、エラーメッセージが表示されること' do
+      patch password_reset_path(@user.reset_token), params: { email: @user.email,
+                                                              user: { password: 'foobaz',
+                                                                      password_confirmation: 'barquux' } }
+      expect(response.body).to include '<div id="error_explanation">'
+    end
+
+    it 'パスワードが空なら、エラーメッセージが表示されること' do
+      patch password_reset_path(@user.reset_token), params: { email: @user.email,
+                                                              user: { password: '',
+                                                                      password_confirmation: '' } }
+      expect(response.body).to include '<div id="error_explanation">'
+    end
+  end
+end


### PR DESCRIPTION
Railsチュートリアル12章を参考に、パスワードの再設定機能の実装をしました。
・ログイン画面にforgot passwordボタンを追加
→クリックでメールアドレス入力画面
→正しいメールアドレス（有効化されたアカウントが持っている・データベースに存在するメールアドレス）を入力されるとメールを送信
→メールに添付されているURL（有効期間２時間）を踏むことでパスワードリセット用の画面を表示
→入力されたパスワードが有効な文字列（6文字以上）である場合、パスワードを入力されたものに更新・ログイン状態に遷移

参考：
Railsチュートリアル
https://railstutorial.jp/chapters/password_reset?version=5.1#cha-password_reset
RailsチュートリアルのテストをRSpecで書き換える
https://zenn.dev/fu_ga/books/ff025eaf9eb387